### PR TITLE
API GET and POST (option to edit only)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1548,6 +1548,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@handlebars/allow-prototype-access": "^1.0.3",
     "body-parser": "^1.19.0",
     "cookie-parser": "^1.4.5",
+    "cors": "^2.8.5",
     "cypress": "^6.4.0",
     "express": "^4.17.1",
     "express-handlebars": "^5.2.0",

--- a/server.js
+++ b/server.js
@@ -3,7 +3,14 @@ const Handlebars = require('handlebars');
 const expressHandlebars = require('express-handlebars');
 const {allowInsecurePrototypeAccess} = require('@handlebars/allow-prototype-access');
 const { Op } = require("sequelize");
+const { request, response } = require("express");
 
+const bodyParser = require('body-parser');
+const cors = require('cors')
+
+const { Board } = require('./Models/Board')
+const { Area } = require('./Models/Area')
+const { Task } = require('./Models/Task')
 
 
 const app = express();
@@ -19,6 +26,11 @@ app.set('view engine', 'handlebars')
 
 app.use(express.static("public"));
 
+app.use(cors())
+
+app.use(bodyParser.json({type:"application/json"}));
+
+
 app.get('/', async (request, response) => {
     response.render("homePage");
 })
@@ -33,6 +45,165 @@ app.get('/boardsList/', async (request, response) => {
 })
 
 
+app.route("/api/board/:boardId")
+.get(async (request, response) =>{
+    const boardId = request.params.boardId
+    if (boardId == "all"){
+        await Board.findAll({
+            include: [
+                {model: Area, as: "areas",
+                include:[
+                    {model: Task, as: "tasks"}
+                ]}
+            ]
+        }).then(board=>{
+            response.json(board).status(200).end()
+        }).catch(error =>{
+            response.status(404).send("Error 404").end()
+        })
+    }
+    else{
+        await Board.findOne({
+            where:{
+                id : boardId
+            },
+            include: [
+                {model: Area, as: "areas",
+                include:[
+                    {model: Task, as: "tasks"}
+                ]}
+            ]
+        }).then(board =>{
+            if (!board){
+                response.status(404).send("Error 404").end()
+            }else{
+                response.json(board).status(200).end()
+            }
+            
+        }).catch(error =>{
+            response.status(404).send("Error 404").end()
+        })
+    }
+})
+
+
+app.post("/api/board/:boardId/editTitle", async (request, response)=>{
+    const boardId = request.params.boardId
+    const board = await Board.findOne({
+        where:{
+            id : boardId
+        }
+    })
+    if (!board){
+        response.status(404).send(`Board with id ${boardId} can not be found`).end()
+    }
+    else{
+        const data = request.body
+        console.log(data[Object.keys(data)[0]])
+        board.name = data[Object.keys(data)[0]]
+        board.save()
+        
+        response.status(200).end()
+    }
+})
+
+app.post("/api/board/:boardId/area/:areaId/editTitle", async (request, response)=>{
+    const boardId = request.params.boardId
+    const areaId = request.params.areaId
+
+    const board = await Board.findOne({
+        where:{
+            id : boardId
+        }
+    })
+    if (!board){
+        response.status(404).send(`Board with id ${boardId} can not be found`).end()
+    }
+    else{
+        const area = await Area.findOne({
+            where:{
+                boardId: boardId,
+                id: areaId
+            }
+        })
+        if (!area){
+            response.status(404).send(`Area with id ${areaId} can not be found on board ${boardId}`).end()
+        }
+        else{
+            const data = request.body
+
+            area.title = data[Object.keys(data)[0]]
+    
+            area.save();
+    
+            response.status(200).end()
+        }
+    }
+})
+
+app.post("/api/board/:boardId/area/:areaId/task/:taskId/editTask", async (request, response) =>{
+    const boardId = request.params.boardId
+    const areaId = request.params.areaId
+    const taskId = request.params.taskId
+
+    const board = await Board.findOne({
+        where:{
+            id : boardId
+        }
+    })
+    if (!board){
+        response.status(404).send(`Board with id ${boardId} can not be found`).end()
+    }
+    else{
+        const area = await Area.findOne({
+            where:{
+                boardId: boardId,
+                id: areaId
+            }
+        })
+        if (!area){
+            response.status(404).send(`Area with id ${areaId} can not be found on board ${boardId}`).end()
+        }
+        else{
+            const task = await Task.findOne({
+                where:{
+                    areaId: areaId,
+                    id: taskId
+                }
+            })
+            if (!task){
+                response.status(404).send(`Task with id ${taskId} can not be found on area ${areaId} at board ${boardId}`).end()
+            }
+            else{
+                const data = request.body
+
+                if (!(Object.keys(data)[0] == "title")){
+                    response.status(400).send("Task object must contain property called 'title' ").end();
+                }
+                else if (!(Object.keys(data)[1] == "text")){
+                    response.status(400).send("Task object must contain property called 'text' ").end();
+                }
+                else if (!(Object.keys(data)[2] == "labels")){
+                    response.status(400).send("Task object must contain property called 'labels' ").end();
+                }
+                else if (!(data.labels instanceof Array)){
+                    response.status(400).send("Task labels must be an array").end();
+                }
+                else{
+                    task.title = data.title
+                    task.text = data.text
+                    task.labels = data.labels
+                    
+                    task.save();
+
+                    response.status(200).end()
+                }
+
+            }
+        }
+    }
+
+})
 
 
 app.listen(port, ()=>{


### PR DESCRIPTION
## I added 2 API Get routes
`http://localhost:3000/api/board/<boardID>`  it returns a json of the entire board
`http://localhost:3000/api/board/all`  it returns every board as a son

## 3 POSTs to edit
`http://localhost:3000/api/board/<boardID>/editTitle`
it takes in any json data, e.g.
```json
{
    "title": "999999999"
}
```
it changes the board title

-----------
`http://localhost:3000/api/board/<boardID/area/<areaID/editTitle` *areas are the columns in the board
it takes in any json data, e.g.
```json
{
    "title": "999999999"
}
```
it changes the area title on a given board

-----------------
`http://localhost:3000/api/board/<boardID>/area/<areaID>/task/<taskID>/editTask`
it takes in the following json data
```json
{
    "title": "Test task",
    "text": "i'm a good task",
    "labels": ["Front-end","Design"]
}
```
## About the PR

I've added some API error handling to avoid server side errors and tested the API with Postman on the mock database however to ensure the functionality before approving it, it would be nice if it would be tested again.

